### PR TITLE
Handle missions without station names

### DIFF
--- a/checkio_client/utils/code.py
+++ b/checkio_client/utils/code.py
@@ -59,6 +59,7 @@ def gen_filename(slug, station, folder=None):
     domain_data = conf.default_domain_data
     if folder is None:
         folder = domain_data.get('solutions')
+    station = station or 'Old'
     return os.path.join(folder, station, slug.replace('-', '_') + '.' + domain_data['extension'])
 
 def gen_env_line(slug):


### PR DESCRIPTION
A couple missions don't belong to stations, e.g. Stressful Subject, Periodic Table, etc. This breaks `checkio sync` with a type error.

I am not certain `'Old'` is what you want the default station name to be, but I mainly wanted to bring this to your attention.